### PR TITLE
Update caching_with_rails.md regarding extension in filename [ci skip]

### DIFF
--- a/guides/source/caching_with_rails.md
+++ b/guides/source/caching_with_rails.md
@@ -191,10 +191,10 @@ render(partial: 'hotels/hotel', collection: @hotels, cached: true)
 
 Will load a file named `hotels/hotel.erb`.
 
-Another option is to include the full filename of the partial to render.
+Another option is to include the `formats` attribute to the partial to render.
 
 ```ruby
-render(partial: 'hotels/hotel.html.erb', collection: @hotels, cached: true)
+render(partial: 'hotels/hotel', collection: @hotels, formats: :html, cached: true)
 ```
 
 Will load a file named `hotels/hotel.html.erb` in any file MIME type, for example you could include this partial in a JavaScript file.


### PR DESCRIPTION


### Motivation / Background

This Pull Request has been created because the documentation is out-of-sync.


### Detail

Since #39164 extension in filename are deprecated (shipped with Rails 6.1)
And has been removed in Rails 7.0.

### Additional information

N/A

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
